### PR TITLE
fix: increase the translation key display limit

### DIFF
--- a/app/packs/src/decidim/term_customizer/admin/translations_admin.js
+++ b/app/packs/src/decidim/term_customizer/admin/translations_admin.js
@@ -41,6 +41,7 @@ $(() => {
         item.innerHTML = replacedText;
         item.dataset.value = valueItem.value;
       },
+      maxResults: 200,
       dataSource
     });
   };


### PR DESCRIPTION
🎩 Description
FIX: The search bar in the term customizer no longer displays all existing keys during a search

📌 Related Issues

[Notion card](https://www.notion.so/opensourcepolitics/Decidim-app-Cl-s-de-trad-ne-s-affichent-pas-dans-la-barre-de-recherche-du-Term-customizer-bbf7cd1c04d84eddb7a577832fb478b9?pvs=4)

Testing
- Go to admin dashboard
- Go to Term customizer
- Add a 'New translation set' with title/name and remove "contraint"
- Go to this new one translation set
- Click on "add multiple"
- In the search bar, search with "category" term for finding "decidim.proposals.proposals.filters.category"